### PR TITLE
Change "CouchSurfing" to "Hospitality Exchange"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: HackerCouch
-description: CouchSurfing for Hackers
+description: Hospitality exchange for Hackers
 url: https://hackercouch.com
 
 markdown: kramdown


### PR DESCRIPTION
Since Couchsurfing isn't a general term but name of a company. 

In the past they've come after others who used their name in such way.
