### PR TITLE
cibuild: fail if couches aren't in couch.md files

### DIFF
--- a/_script/cibuild
+++ b/_script/cibuild
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
+# Make sure all _couches have sane filenames.
+badcouches=$(find ./_couches -type f -not -name \*.md)
+if [ ! -z ${badcouches} ]; then
+	for c in "${badcouches}"; do
+		echo "$c: couch should be named foo.md"
+	done
+	false
+fi
+
 bundle exec jekyll doctor
 bundle exec jekyll build
 bundle exec htmlproof ./_site/


### PR DESCRIPTION
Ensure that cleanups like Issue #34 won't be needed again.
