### PR TITLE
Make it easier to run local installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,22 @@ I also made a similar PR-based DNS redirect service called [lightsaber][ls] rece
 
 # Development
 
-HackerCouch uses Jekyll Collections, which is a feature I really like.
-Hosted on github-pages, duh.
-Builds use travis, and make sure that the site has proper html before its deployed
+- HackerCouch uses [Jekyll](http://jekyllrb.com/) Collections, which is a feature I really like.
+- Hosted on Github pages, duh.
+- Builds use Travis, and make sure that the site has proper html before its deployed.
+
+### Quickstart:
+```bash
+. ./_script/setup-env.sh
+gem install bundler
+bundle install
+jekyll serve
+```
+
+And open [http://localhost:4000](http://localhost:4000) in your browser.
+
+### Troubleshooting
+- If your bundle fails due Nokogiri and you're on OSX, try running this first: `xcode-select --install`
 
 # Credits
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ I also made a similar PR-based DNS redirect service called [lightsaber][ls] rece
 . ./_script/setup-env.sh
 gem install bundler
 bundle install
-jekyll serve
+jekyll serve --watch
 ```
 
 And open [http://localhost:4000](http://localhost:4000) in your browser.

--- a/_script/setup-env.sh
+++ b/_script/setup-env.sh
@@ -1,0 +1,18 @@
+# source.  don't exec.
+
+# Use a self-contained 'gemset' under 'rvm' for hacking on hackercouch
+# without polluting the rest of your environment with its dependencies.
+
+if [[ ! -s $HOME/.rvm/scripts/rvm ]]; then
+	echo "\033[31;4;1mError: rvm not installed\033[0m"
+	echo "Read the instructions at https://rvm.io/rvm/install/."
+	echo
+	echo "Note well: the rvm installation will modify your shellrc"
+	echo "files in a trojan-esque way.  Carefully audit your .z* or"
+	echo "your .bash* and .profile files after installation!"
+	return
+fi
+
+source $HOME/.rvm/scripts/rvm
+source $(rvm env --path)
+rvm gemset use hackercouch --create


### PR DESCRIPTION
This builds on @simison's work in #41.  Makes it a little easier for hackers unfamiliar with the web environment to hack on Hackercouch.  I learned about RVM from FOSDEM a couple of years ago and found a `setup-env.sh` script like this to be helpful.  If there are better ways to set up light(ish)-weight environments for hacking on web things, I'd love to have my mind expanded. :)
