### PR TITLE
Remove non-existing twitter handle

### DIFF
--- a/_couches/raincrash.md
+++ b/_couches/raincrash.md
@@ -5,7 +5,6 @@ country: IN
 region: Koramangala
 email: sricharanized@gmail.com
 github: raincrash
-twitter: Sricharanized
 website: http://sricharan.xyz
 facebook: Sricharanized
 ---


### PR DESCRIPTION
@raincrash our build is failing because your Twitter handle returns 404:

https://twitter.com/Sricharanized

— so I'll just remove it for now, feel free to send a PR to add correct handle here again. 

Cheers!
