### PR TITLE
Remove HTTP status 500'ing website

### DIFF
--- a/_couches/arthur.md
+++ b/_couches/arthur.md
@@ -1,7 +1,6 @@
 ---
 github: kprovost
 email: kristof@sigsegv.be
-website: http://www.sigsegv.be/
 city: Grimbergen
 country: BE
 ---


### PR DESCRIPTION
FYI @kprovost, I've removed website URL from your profile on https://hackercouch.com/ since it's HTTP 500 erroring. If you'd like to add it back, just open a PR. Thanks!

https://travis-ci.org/hackercouch/hackercouch/builds/536884052