### PR TITLE
Re-add my (now fixed) website

### DIFF
--- a/_couches/arthur.md
+++ b/_couches/arthur.md
@@ -1,6 +1,7 @@
 ---
 github: kprovost
 email: kristof@sigsegv.be
+website: https://www.sigsegv.be/
 city: Grimbergen
 country: BE
 ---


### PR DESCRIPTION
The website works again (and is now monitered more closely by Icinga),
so it can be re-added.

Thanks for the heads-up on the breakage! It was already monitored by Icinga2, but it didn't notice this breakage. That's also been fixed.