### PR TITLE
Check external links in CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ task :test do
       /hitchwiki/,
       /steemit/
     ],
-    :disable_external => true,
     :enforce_https => false,
     :cache => {
       :timeframe => { :internal => '7d' }
@@ -20,8 +19,11 @@ task :test do
         "User-Agent" => "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36"
       },
       :followlocation => true,
-      :connecttimeout => 3,
-      :timeout => 5
+      :connecttimeout => 5,
+      :timeout => 15
+    },
+    hydra: {
+      :max_concurrency => 3
     },
     :parallel => {
       :in_processes => 3


### PR DESCRIPTION
Increase timeouts and reduce parallelism.  Some sites are a little slow to respond.  Hammering others with too many requests in parallel makes them return 429 (e.g. github.com).

This makes CI considerably slower but it will improve the overall accuracy of the data.