### PR TITLE
Use cache@v3 for GitHub workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,12 @@ jobs:
     # The cache is written to at the end of the build
     # If the build is successful
     - name: Cache htmlproofer and open-uri network calls
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           _cache
           /tmp/.htmlproofer
-        key: hackercouch
+        key: ${{ runner.os }}-network
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: "3.1"


### PR DESCRIPTION
cache@v2 produces a CI warning about the not-quite-imminent deprecation of the save-state and set-output commands.  Bump to cache@v3 to ensure things continue to work post-deprecation.